### PR TITLE
Add config file support, instructions on using it in the readme, and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # sxbar
 The simple, yet powerful, status bar for Xorg.
+
+## Configuration
+sxbar can be configured using a configuration file located at `~/.config/sxbarrc`. If this file doesn't exist, sxbar will use the default values from `config.h`.
+
+To get started with configuration:
+
+1. Copy the example config file:
+   ```bash
+   mkdir -p ~/.config
+   cp sxbarrc.example ~/.config/sxbarrc
+   ```
+
+2. Edit the config file to your liking:
+   ```
+   # Colors (hex format)
+   background_color: #56002e
+   foreground_color: #ffffff
+   border_color: #005577
+   ```
+
+The configuration uses a simple `key: value` format. Lines starting with `#` are treated as comments.

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include "parser.h"
+#include "config.h"
+
+#define MAX_LINE_LENGTH 256
+
+static void trim(char *str) {
+    char *start = str;
+    while(isspace(*start)) start++;
+    
+    if(start != str) {
+        memmove(str, start, strlen(start) + 1);
+    }
+
+    char *end = str + strlen(str) - 1;
+    while(end > str && isspace(*end)) {
+        *end = '\0';
+        end--;
+    }
+}
+
+Config parse_config_file(const char *path) {
+    Config config;
+    // Set defaults from config.h
+    strncpy(config.bg_color, BAR_COLOR_BG, sizeof(config.bg_color) - 1);
+    strncpy(config.fg_color, BAR_COLOR_FG, sizeof(config.fg_color) - 1);
+    strncpy(config.border_color, BAR_COLOR_BORDER, sizeof(config.border_color) - 1);
+
+    FILE *file = fopen(path, "r");
+    if (!file) {
+        return config; // Return default config if file doesn't exist
+    }
+
+    char line[MAX_LINE_LENGTH];
+    while (fgets(line, sizeof(line), file)) {
+        // Remove newline
+        line[strcspn(line, "\n")] = 0;
+        
+        // Skip comments and empty lines
+        if (line[0] == '#' || line[0] == '\0') {
+            continue;
+        }
+
+        char *key = strtok(line, ":");
+        char *value = strtok(NULL, "\n");
+        
+        if (!key || !value) {
+            continue;
+        }
+
+        // Trim whitespace
+        trim(key);
+        trim(value);
+
+        // Parse the values
+        if (strcmp(key, "background_color") == 0) {
+            strncpy(config.bg_color, value, sizeof(config.bg_color) - 1);
+        } else if (strcmp(key, "foreground_color") == 0) {
+            strncpy(config.fg_color, value, sizeof(config.fg_color) - 1);
+        } else if (strcmp(key, "border_color") == 0) {
+            strncpy(config.border_color, value, sizeof(config.border_color) - 1);
+        }
+    }
+
+    fclose(file);
+    return config;
+}

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,0 +1,14 @@
+#ifndef PARSER_H
+#define PARSER_H
+
+// Config structure to hold parsed values
+typedef struct {
+    char bg_color[9];      // Including null terminator
+    char fg_color[9];
+    char border_color[9];
+} Config;
+
+// Parse the config file and return a Config struct
+Config parse_config_file(const char *path);
+
+#endif // PARSER_H

--- a/sxbarrc.example
+++ b/sxbarrc.example
@@ -1,0 +1,7 @@
+# sxbar configuration file
+# Place this file at ~/.config/sxbarrc
+
+# Colors (hex format)
+background_color: #56002e
+foreground_color: #ffffff
+border_color: #005577


### PR DESCRIPTION
…an example config file. All that's supported currently is just background color, foreground color, and border color.

Apologies for any bloat, this is heavily AI generated. I tried to follow the same config convention as sxwm.