### PR TITLE
added new workspace option "only_active" and module positions

### DIFF
--- a/default_sxbarc
+++ b/default_sxbarc
@@ -17,31 +17,37 @@ module.0.name       : clock
 module.0.cmd        : date '+%H:%M:%S'
 module.0.enabled    : true
 module.0.interval   : 1
+module.0.position   : right
 
 module.1.name       : date
 module.1.cmd        : date '+%Y-%m-%d'
 module.1.enabled    : true
 module.1.interval   : 60
+module.1.position   : right
 
 module.2.name       : battery
 module.2.cmd        : cat /sys/class/power_supply/BAT0/capacity 2>/dev/null | sed 's/$/%/' || echo 'N/A'
 module.2.enabled    : false
 module.2.interval   : 30
+module.2.position   : right
 
 module.3.name       : volume
 module.3.cmd        : amixer get Master | grep -o '[0-9]*%' | head -1 || echo 'N/A'
 module.3.enabled    : true
 module.3.interval   : 5
+module.3.position   : right
 
 module.4.name       : cpu
 module.4.cmd        : top -bn1 | grep 'Cpu(s)' | sed 's/.*, *\([0-9.]*\)%* id.*/\1/' | awk '{print 100-$1"%"}'
 module.4.enabled    : true
 module.4.interval   : 3
+module.4.position   : right
 
 module.5.name       : mem
 module.5.cmd        : free -h | awk '/^Mem/ { print $3 }' | sed s/i//g
 module.5.enabled    : true
 module.5.interval   : 3
+module.5.position   : right
 
 workspaces.labels              : one two three four five six seven eight nine
 workspaces.active_background   : #717394
@@ -52,3 +58,4 @@ workspaces.padding_left        : 10
 workspaces.padding_right       : 10
 workspaces.spacing             : 0
 workspaces.position            : left
+workspaces.only_active		   : true

--- a/src/defs.h
+++ b/src/defs.h
@@ -11,6 +11,12 @@
 
 #define PATH_MAX 4096
 
+typedef enum {
+	MOD_POS_LEFT = 0,
+	/* CENTER IS CURRENTLY UNSUPPORTED :( */
+	MOD_POS_RIGHT = 1
+} ModulePosition;
+
 typedef struct Module {
 	char *name;
 	char *command;
@@ -18,6 +24,7 @@ typedef struct Module {
 	int refresh_interval;
 	time_t last_update;
 	char *cached_output;
+	ModulePosition mod_position;
 } Module;
 
 typedef enum {
@@ -63,6 +70,7 @@ typedef struct Config {
 	int ws_pad_right;
 	int ws_spacing;
 	WorkspacePosition ws_position;
+	int ws_only_active;
 } Config;
 
 typedef void (*EventHandler)(XEvent *);

--- a/src/parser.c
+++ b/src/parser.c
@@ -127,6 +127,9 @@ void parse_config(const char *filepath, Config *cfg)
 			else if (!strcmp(field, "spacing")) {
 				cfg->ws_spacing = atoi(value);
 			}
+			else if (!strcmp(field, "only_active")) {
+				cfg->ws_only_active = !strcmp(value, "true");
+			}
 			else if (!strcmp(field, "position")) {
 				if (!strcasecmp(value, "left")) {
 					cfg->ws_position = WS_POS_LEFT;
@@ -191,6 +194,7 @@ void parse_config(const char *filepath, Config *cfg)
 					cfg->modules[i].cached_output = NULL;
 					cfg->modules[i].name = NULL;
 					cfg->modules[i].command = NULL;
+					cfg->modules[i].mod_position = MOD_POS_RIGHT;
 				}
 				cfg->module_count = idx + 1;
 			}
@@ -213,6 +217,17 @@ void parse_config(const char *filepath, Config *cfg)
 				int iv = atoi(value);
 				if (iv > 0) {
 					m->refresh_interval = iv;
+				}
+			}
+			else if (!strcmp(field, "position")) {
+				if (!strcasecmp(value, "left")) {
+					m->mod_position = MOD_POS_LEFT;
+				}
+				else if (!strcasecmp(value, "right")) {
+					m->mod_position = MOD_POS_RIGHT;
+				}
+				else {
+					m->mod_position = MOD_POS_RIGHT; 
 				}
 			}
 			continue;

--- a/src/sxbar.c
+++ b/src/sxbar.c
@@ -464,14 +464,20 @@ void draw_bar_into(Drawable draw, int monitor_index)
 		if (!config.modules[i].enabled || !config.modules[i].cached_output) {
 			continue;
 		}
-		modules_total_w += xft_text_width(config.modules[i].cached_output) + 20;
+		if (config.modules[i].mod_position == MOD_POS_RIGHT) {
+			modules_total_w += xft_text_width(config.modules[i].cached_output) + 20;
+		}
 	}
 	int modules_block_left = w - modules_total_w - 2 * config.text_padding;
 
 	int ws_start_x;
 	switch (config.ws_position) {
 		case WS_POS_CENTER:
-			ws_start_x = (w - ws_segment_width) / 2;
+			if (!config.ws_only_active) {
+				ws_start_x = (w - ws_segment_width) / 2;
+			} else {
+				ws_start_x = w / 2;
+			}
 			break;
 		case WS_POS_RIGHT:
 			/* keep space for modules on far right */
@@ -488,37 +494,63 @@ void draw_bar_into(Drawable draw, int monitor_index)
 
 	/* draw workspaces */
 	if (labels) {
-		int cur_x = ws_start_x;
-		for (int i = 0; i < label_count; i++) {
+		if (config.ws_only_active) {
 			char tmp[128];
-			snprintf(tmp, sizeof tmp, "%s", labels[i]);
+			snprintf(tmp, sizeof tmp, "%s", labels[current_ws]);
 			int tw = xft_text_width(tmp);
 			int box_w = tw + config.ws_pad_left + config.ws_pad_right;
-			unsigned box_x = cur_x;
+			
+			ws_segment_width = tw + config.ws_pad_left + config.ws_pad_right;
+			ws_start_x = (w - ws_segment_width) / 2;
+
+			unsigned box_x = ws_start_x;
 			unsigned box_y = text_y - font->ascent - config.ws_pad_left;
 			unsigned box_h = font->ascent + font->descent + config.ws_pad_left + config.ws_pad_right;
 
 			/* background */
-			XSetForeground(dpy, gc, (i == current_ws) ? config.ws_active_bg : config.ws_inactive_bg);
+			XSetForeground(dpy, gc, config.ws_inactive_bg);
 			XFillRectangle(dpy, draw, gc, box_x, box_y, box_w, box_h);
 
 			/* text */
-			if (i == current_ws) {
-				XftDrawStringUtf8(
-					xd, &xft_ws_active_fg, font,
-					box_x + config.ws_pad_left, text_y,
-					(const FcChar8 *)tmp, strlen(tmp)
-				);
-			}
-			else {
-				XftDrawStringUtf8(
-					xd, &xft_ws_inactive_fg, font,
-					box_x + config.ws_pad_left, text_y,
-					(const FcChar8 *)tmp, strlen(tmp)
-				);
-			}
+			XftDrawStringUtf8(
+				xd, &xft_ws_inactive_fg, font,
+				box_x + config.ws_pad_left, text_y,
+				(const FcChar8 *)tmp, strlen(tmp)
+			);
+		} else {
+			int cur_x = ws_start_x;
+			for (int i = 0; i < label_count; i++) {
+				char tmp[128];
+				snprintf(tmp, sizeof tmp, "%s", labels[i]);
+				int tw = xft_text_width(tmp);
+				int box_w = tw + config.ws_pad_left + config.ws_pad_right;
 
-			cur_x += box_w + config.ws_spacing;
+				unsigned box_x = cur_x;
+				unsigned box_y = text_y - font->ascent - config.ws_pad_left;
+				unsigned box_h = font->ascent + font->descent + config.ws_pad_left + config.ws_pad_right;
+
+				/* background */
+				XSetForeground(dpy, gc, (i == current_ws) ? config.ws_active_bg : config.ws_inactive_bg);
+				XFillRectangle(dpy, draw, gc, box_x, box_y, box_w, box_h);
+
+				/* text */
+				if (i == current_ws) {
+					XftDrawStringUtf8(
+						xd, &xft_ws_active_fg, font,
+						box_x + config.ws_pad_left, text_y,
+						(const FcChar8 *)tmp, strlen(tmp)
+					);
+				}
+				else {
+					XftDrawStringUtf8(
+						xd, &xft_ws_inactive_fg, font,
+						box_x + config.ws_pad_left, text_y,
+						(const FcChar8 *)tmp, strlen(tmp)
+					);
+				}
+
+				cur_x += box_w + config.ws_spacing;
+			}
 		}
 	}
 
@@ -532,14 +564,23 @@ void draw_bar_into(Drawable draw, int monitor_index)
 
 	/* modules */
 	int mx = w - modules_total_w - 2 * config.text_padding;
+	int mxl = 20 + config.text_padding; /* module starting x position for left drawing modules */
 	for (int i = 0; i < config.module_count; i++) {
 		if (!config.modules[i].enabled || !config.modules[i].cached_output) {
 			continue;
 		}
 		char *out = config.modules[i].cached_output;
 		int tw = xft_text_width(out);
-		XftDrawStringUtf8(xd, &xft_fg, font, mx, text_y, (const FcChar8 *)out, strlen(out));
-		mx += tw + 20;
+		switch (config.modules[i].mod_position) {
+			case MOD_POS_RIGHT:
+				XftDrawStringUtf8(xd, &xft_fg, font, mx, text_y, (const FcChar8 *)out, strlen(out));
+				mx += tw + 20;
+				break;
+			case MOD_POS_LEFT:
+				XftDrawStringUtf8(xd, &xft_fg, font, mxl, text_y, (const FcChar8 *)out, strlen(out));
+				mxl += tw + 20;
+				break;
+		}
 	}
 
 	XftDrawDestroy(xd);
@@ -655,6 +696,7 @@ void init_defaults(void)
 	config.ws_pad_right = 5;
 	config.ws_spacing = 10;
 	config.ws_position = WS_POS_LEFT;
+	config.ws_only_active = 0;
 }
 
 


### PR DESCRIPTION
this (rough) pull request adds two new features to sxbar, `workspaces.only_active` which enables the workspace module to only display the active workspace, and `modules.X.position`, adding the possibility for a module to be either at the left or the right side of the bar.

possible values for:

- `workspaces.only_active`: `true`, `false`, defaults to `false`
- `modules.X.position`: `right`, `left`, defaults to `right`

